### PR TITLE
Refactor ingestion and analytics routes to share database configuration

### DIFF
--- a/server.js
+++ b/server.js
@@ -69,7 +69,7 @@ async function startServer() {
 
     // Initialize RAG analytics routes
     console.log('📊 Initializing RAG analytics routes...');
-    await initializeRAGAnalyticsRoutes();
+    await initializeRAGAnalyticsRoutes(database);
     console.log('✅ RAG Analytics routes initialized successfully');
 
     // Mount simple admin routes


### PR DESCRIPTION
## Summary
- reuse the shared DatabaseConfig instance when creating ingestion source records
- refactor the RAG analytics routes to consume the centralized database helper instead of creating a new pg pool
- pass the initialized database instance into the analytics route initializer during server startup

## Testing
- npx jest --config jest.config.js --runTestsByPath tests/unit/sample.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d0c85439348333b7d51ddd06cf51e9