### PR TITLE
Secure simple admin routes with RBAC and add tests

### DIFF
--- a/__tests__/integration/simple-admin-auth.test.js
+++ b/__tests__/integration/simple-admin-auth.test.js
@@ -1,0 +1,238 @@
+const request = require('supertest');
+const express = require('express');
+
+const initialConfigStore = {
+  rag: {
+    response: {
+      confidenceThreshold: 0.6,
+      maxTokens: 1000,
+      temperature: 0.3,
+      enableCitationValidation: true,
+    },
+    retrieval: {
+      maxChunks: 5,
+      diversityThreshold: 0.8,
+      enableHybridSearch: false,
+    },
+    confidence: {
+      minimumThreshold: 0.6,
+    },
+  },
+  vector: {
+    maxRetrievedChunks: 5,
+  },
+};
+
+let configStore = JSON.parse(JSON.stringify(initialConfigStore));
+
+const syncTopLevelReferences = (config) => {
+  config.rag = configStore.rag;
+  config.vector = configStore.vector;
+};
+
+const configStub = {
+  get(path) {
+    return path.split('.').reduce((acc, key) => (acc !== undefined ? acc[key] : undefined), configStore);
+  },
+  set(path, value) {
+    const keys = path.split('.');
+    let current = configStore;
+
+    for (let i = 0; i < keys.length - 1; i++) {
+      const key = keys[i];
+      if (!current[key] || typeof current[key] !== 'object') {
+        current[key] = {};
+      }
+      current = current[key];
+    }
+
+    current[keys[keys.length - 1]] = value;
+    syncTopLevelReferences(configStub);
+    return value;
+  },
+  reset() {
+    configStore = JSON.parse(JSON.stringify(initialConfigStore));
+    syncTopLevelReferences(configStub);
+  },
+};
+
+syncTopLevelReferences(configStub);
+
+jest.mock('../../config/environment', () => {
+  const actual = jest.requireActual('../../config/environment');
+  return {
+    ...actual,
+    getConfig: jest.fn(() => configStub),
+  };
+});
+
+const createSimpleAdminRouter = require('../../routes/simple-admin');
+const { getConfig } = require('../../config/environment');
+
+class MockRBACManager {
+  constructor(tokensByValue) {
+    this.tokensByValue = tokensByValue;
+  }
+
+  createAuthMiddleware(requiredPermission) {
+    return (req, res, next) => {
+      const authHeader = req.headers.authorization;
+      if (!authHeader || !authHeader.startsWith('Bearer ')) {
+        return res.status(401).json({ error: 'Authorization token required' });
+      }
+
+      const tokenValue = authHeader.substring(7);
+      const user = this.tokensByValue[tokenValue];
+
+      if (!user) {
+        return res.status(401).json({ error: 'Invalid token' });
+      }
+
+      if (requiredPermission && !user.permissions.includes(requiredPermission)) {
+        return res.status(403).json({
+          error: 'Insufficient permissions',
+          required: requiredPermission,
+        });
+      }
+
+      req.user = user;
+      req.token = tokenValue;
+      next();
+    };
+  }
+}
+
+describe('Simple Admin RAG configuration authorization', () => {
+  let app;
+  let configManager;
+  const TOKENS = {
+    admin: 'admin-token',
+    compliance: 'compliance-token',
+    analyst: 'analyst-token',
+  };
+
+  beforeAll(() => {
+    configManager = getConfig();
+    configManager.reset();
+  });
+
+  beforeEach(() => {
+    const mockRBACManager = new MockRBACManager({
+      [TOKENS.admin]: {
+        id: 1,
+        username: 'admin-user',
+        role: 'admin',
+        permissions: ['system:monitor', 'system:configure'],
+      },
+      [TOKENS.compliance]: {
+        id: 2,
+        username: 'compliance-user',
+        role: 'compliance_officer',
+        permissions: ['system:monitor'],
+      },
+      [TOKENS.analyst]: {
+        id: 3,
+        username: 'analyst-user',
+        role: 'analyst',
+        permissions: ['data:read'],
+      },
+    });
+
+    app = express();
+    app.use(express.json());
+    app.use('/api/admin', createSimpleAdminRouter({ rbacManager: mockRBACManager }));
+  });
+
+  afterEach(() => {
+    configManager.reset();
+  });
+
+  describe('GET /api/admin/rag/config', () => {
+    it('rejects requests without authentication', async () => {
+      const response = await request(app).get('/api/admin/rag/config');
+
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({ error: 'Authorization token required' });
+    });
+
+    it('allows roles with monitor permission to view the configuration', async () => {
+      const response = await request(app)
+        .get('/api/admin/rag/config')
+        .set('Authorization', `Bearer ${TOKENS.compliance}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.config).toMatchObject({
+        confidenceThreshold: expect.any(Number),
+        responseMaxTokens: expect.any(Number),
+        responseTemperature: expect.any(Number),
+      });
+    });
+
+    it('rejects roles without the required permission', async () => {
+      const response = await request(app)
+        .get('/api/admin/rag/config')
+        .set('Authorization', `Bearer ${TOKENS.analyst}`);
+
+      expect(response.status).toBe(403);
+      expect(response.body).toEqual({
+        error: 'Insufficient permissions',
+        required: 'system:monitor',
+      });
+    });
+  });
+
+  describe('PUT /api/admin/rag/config', () => {
+    it('rejects updates without authentication', async () => {
+      const response = await request(app)
+        .put('/api/admin/rag/config')
+        .send({ responseMaxTokens: 1200 });
+
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({ error: 'Authorization token required' });
+    });
+
+    it('rejects updates for roles without configure permission', async () => {
+      const response = await request(app)
+        .put('/api/admin/rag/config')
+        .set('Authorization', `Bearer ${TOKENS.compliance}`)
+        .send({ responseMaxTokens: 1500 });
+
+      expect(response.status).toBe(403);
+      expect(response.body).toEqual({
+        error: 'Insufficient permissions',
+        required: 'system:configure',
+      });
+    });
+
+    it('allows administrator roles to update configuration and persists changes', async () => {
+      const payload = {
+        confidenceThreshold: 0.7,
+        responseMaxTokens: 1600,
+        responseTemperature: 0.45,
+        enableCitationValidation: false,
+        retrievalMaxChunks: 7,
+        diversityThreshold: 0.85,
+        enableHybridSearch: true,
+      };
+
+      const response = await request(app)
+        .put('/api/admin/rag/config')
+        .set('Authorization', `Bearer ${TOKENS.admin}`)
+        .send(payload);
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.updates).toMatchObject(payload);
+
+      expect(configManager.get('rag.response.confidenceThreshold')).toBe(payload.confidenceThreshold);
+      expect(configManager.get('rag.response.maxTokens')).toBe(payload.responseMaxTokens);
+      expect(configManager.get('rag.response.temperature')).toBe(payload.responseTemperature);
+      expect(configManager.get('rag.response.enableCitationValidation')).toBe(payload.enableCitationValidation);
+      expect(configManager.get('rag.retrieval.maxChunks')).toBe(payload.retrievalMaxChunks);
+      expect(configManager.get('vector.maxRetrievedChunks')).toBe(payload.retrievalMaxChunks);
+      expect(configManager.get('rag.retrieval.diversityThreshold')).toBe(payload.diversityThreshold);
+      expect(configManager.get('rag.retrieval.enableHybridSearch')).toBe(payload.enableHybridSearch);
+    });
+  });
+});

--- a/routes/simple-admin.js
+++ b/routes/simple-admin.js
@@ -7,7 +7,7 @@ const express = require('express');
 const { body, validationResult } = require('express-validator');
 const logger = require('../utils/logger');
 const { getConfig } = require('../config/environment');
-const router = express.Router();
+const RBACManager = require('../services/RBACManager');
 
 const normalizeBoolean = (value) => {
   if (typeof value === 'string') {
@@ -16,43 +16,49 @@ const normalizeBoolean = (value) => {
   return Boolean(value);
 };
 
-// Simple test endpoint
-router.get('/test', (req, res) => {
-  res.json({ success: true, message: 'Simple admin routes working!' });
-});
+function createSimpleAdminRouter({ rbacManager } = {}) {
+  const router = express.Router();
+  const manager = rbacManager || new RBACManager();
 
-// RAG configuration endpoints
-router.get('/rag/config', async (req, res) => {
-  try {
-    const configManager = getConfig();
-    const configuredMaxChunks = configManager.get('rag.retrieval.maxChunks');
+  const requireMonitorAccess = manager.createAuthMiddleware('system:monitor');
+  const requireConfigureAccess = manager.createAuthMiddleware('system:configure');
 
-    const ragConfig = {
-      confidenceThreshold: configManager.get('rag.response.confidenceThreshold'),
-      responseMaxTokens: configManager.get('rag.response.maxTokens'),
-      responseTemperature: configManager.get('rag.response.temperature'),
-      enableCitationValidation: configManager.get('rag.response.enableCitationValidation'),
-      retrievalMaxChunks: configuredMaxChunks !== undefined
-        ? configuredMaxChunks
-        : configManager.get('vector.maxRetrievedChunks'),
-      diversityThreshold: configManager.get('rag.retrieval.diversityThreshold'),
-      enableHybridSearch: configManager.get('rag.retrieval.enableHybridSearch'),
-    };
+  // Simple test endpoint
+  router.get('/test', requireMonitorAccess, (req, res) => {
+    res.json({ success: true, message: 'Simple admin routes working!' });
+  });
 
-    res.json({ success: true, config: ragConfig });
+  // RAG configuration endpoints
+  router.get('/rag/config', requireMonitorAccess, async (req, res) => {
+    try {
+      const configManager = getConfig();
+      const configuredMaxChunks = configManager.get('rag.retrieval.maxChunks');
 
-  } catch (error) {
-    logger.error('Failed to get RAG config:', error);
-    res.status(500).json({
-      success: false,
-      error: 'Failed to get RAG configuration',
-      details: error.message
-    });
-  }
-});
+      const ragConfig = {
+        confidenceThreshold: configManager.get('rag.response.confidenceThreshold'),
+        responseMaxTokens: configManager.get('rag.response.maxTokens'),
+        responseTemperature: configManager.get('rag.response.temperature'),
+        enableCitationValidation: configManager.get('rag.response.enableCitationValidation'),
+        retrievalMaxChunks: configuredMaxChunks !== undefined
+          ? configuredMaxChunks
+          : configManager.get('vector.maxRetrievedChunks'),
+        diversityThreshold: configManager.get('rag.retrieval.diversityThreshold'),
+        enableHybridSearch: configManager.get('rag.retrieval.enableHybridSearch'),
+      };
 
-router.put('/rag/config',
-  [
+      res.json({ success: true, config: ragConfig });
+
+    } catch (error) {
+      logger.error('Failed to get RAG config:', error);
+      res.status(500).json({
+        success: false,
+        error: 'Failed to get RAG configuration',
+        details: error.message
+      });
+    }
+  });
+
+  const ragConfigValidators = [
     body('confidenceThreshold').optional().isFloat({ min: 0.0, max: 1.0 }),
     body('responseMaxTokens').optional().isInt({ min: 100, max: 4000 }),
     body('responseTemperature').optional().isFloat({ min: 0.0, max: 2.0 }),
@@ -60,81 +66,88 @@ router.put('/rag/config',
     body('retrievalMaxChunks').optional().isInt({ min: 1, max: 50 }),
     body('diversityThreshold').optional().isFloat({ min: 0.0, max: 1.0 }),
     body('enableHybridSearch').optional().isBoolean(),
-  ],
-  async (req, res) => {
-    try {
-      const errors = validationResult(req);
-      if (!errors.isEmpty()) {
-        return res.status(400).json({
+  ];
+
+  router.put('/rag/config',
+    requireConfigureAccess,
+    ...ragConfigValidators,
+    async (req, res) => {
+      try {
+        const errors = validationResult(req);
+        if (!errors.isEmpty()) {
+          return res.status(400).json({
+            success: false,
+            errors: errors.array()
+          });
+        }
+
+        const configManager = getConfig();
+        const updates = {};
+
+        if (req.body.confidenceThreshold !== undefined) {
+          const thresholdValue = Number(req.body.confidenceThreshold);
+          configManager.set('rag.response.confidenceThreshold', thresholdValue);
+          configManager.set('rag.confidence.minimumThreshold', thresholdValue);
+          updates.confidenceThreshold = thresholdValue;
+        }
+
+        if (req.body.responseMaxTokens !== undefined) {
+          configManager.set('rag.response.maxTokens', Number(req.body.responseMaxTokens));
+          updates.responseMaxTokens = Number(req.body.responseMaxTokens);
+        }
+
+        if (req.body.responseTemperature !== undefined) {
+          configManager.set('rag.response.temperature', Number(req.body.responseTemperature));
+          updates.responseTemperature = Number(req.body.responseTemperature);
+        }
+
+        if (req.body.enableCitationValidation !== undefined) {
+          const value = normalizeBoolean(req.body.enableCitationValidation);
+          configManager.set('rag.response.enableCitationValidation', value);
+          updates.enableCitationValidation = value;
+        }
+
+        if (req.body.retrievalMaxChunks !== undefined) {
+          const maxChunks = Number(req.body.retrievalMaxChunks);
+          configManager.set('rag.retrieval.maxChunks', maxChunks);
+          configManager.set('vector.maxRetrievedChunks', maxChunks);
+          updates.retrievalMaxChunks = maxChunks;
+        }
+
+        if (req.body.diversityThreshold !== undefined) {
+          const diversityThreshold = Number(req.body.diversityThreshold);
+          configManager.set('rag.retrieval.diversityThreshold', diversityThreshold);
+          updates.diversityThreshold = diversityThreshold;
+        }
+
+        if (req.body.enableHybridSearch !== undefined) {
+          const value = normalizeBoolean(req.body.enableHybridSearch);
+          configManager.set('rag.retrieval.enableHybridSearch', value);
+          updates.enableHybridSearch = value;
+        }
+
+        logger.info('RAG configuration updated', {
+          updates: updates,
+        });
+
+        res.json({
+          success: true,
+          message: 'RAG configuration updated successfully',
+          updates: updates
+        });
+
+      } catch (error) {
+        logger.error('Failed to update RAG config:', error);
+        res.status(500).json({
           success: false,
-          errors: errors.array()
+          error: 'Failed to update RAG configuration',
+          details: error.message
         });
       }
-
-      const configManager = getConfig();
-      const updates = {};
-
-      if (req.body.confidenceThreshold !== undefined) {
-        const thresholdValue = Number(req.body.confidenceThreshold);
-        configManager.set('rag.response.confidenceThreshold', thresholdValue);
-        configManager.set('rag.confidence.minimumThreshold', thresholdValue);
-        updates.confidenceThreshold = thresholdValue;
-      }
-
-      if (req.body.responseMaxTokens !== undefined) {
-        configManager.set('rag.response.maxTokens', Number(req.body.responseMaxTokens));
-        updates.responseMaxTokens = Number(req.body.responseMaxTokens);
-      }
-
-      if (req.body.responseTemperature !== undefined) {
-        configManager.set('rag.response.temperature', Number(req.body.responseTemperature));
-        updates.responseTemperature = Number(req.body.responseTemperature);
-      }
-
-      if (req.body.enableCitationValidation !== undefined) {
-        const value = normalizeBoolean(req.body.enableCitationValidation);
-        configManager.set('rag.response.enableCitationValidation', value);
-        updates.enableCitationValidation = value;
-      }
-
-      if (req.body.retrievalMaxChunks !== undefined) {
-        const maxChunks = Number(req.body.retrievalMaxChunks);
-        configManager.set('rag.retrieval.maxChunks', maxChunks);
-        configManager.set('vector.maxRetrievedChunks', maxChunks);
-        updates.retrievalMaxChunks = maxChunks;
-      }
-
-      if (req.body.diversityThreshold !== undefined) {
-        const diversityThreshold = Number(req.body.diversityThreshold);
-        configManager.set('rag.retrieval.diversityThreshold', diversityThreshold);
-        updates.diversityThreshold = diversityThreshold;
-      }
-
-      if (req.body.enableHybridSearch !== undefined) {
-        const value = normalizeBoolean(req.body.enableHybridSearch);
-        configManager.set('rag.retrieval.enableHybridSearch', value);
-        updates.enableHybridSearch = value;
-      }
-
-      logger.info('RAG configuration updated', {
-        updates: updates,
-      });
-
-      res.json({ 
-        success: true, 
-        message: 'RAG configuration updated successfully',
-        updates: updates
-      });
-
-    } catch (error) {
-      logger.error('Failed to update RAG config:', error);
-      res.status(500).json({ 
-        success: false, 
-        error: 'Failed to update RAG configuration',
-        details: error.message 
-      });
     }
-  }
-);
+  );
 
-module.exports = router;
+  return router;
+}
+
+module.exports = createSimpleAdminRouter;

--- a/server.js
+++ b/server.js
@@ -28,9 +28,8 @@ const chatRoutes = require('./routes/chat');
 const documentManagementRoutes = require('./routes/documentManagement');
 const { getRouter: getIngestionRouter, initialize: initializeIngestionRoutes } = require('./routes/ingestion');
 const { getRouter: getRAGAnalyticsRouter, initialize: initializeRAGAnalyticsRoutes } = require('./routes/rag-analytics');
-
-// Import simple admin routes
-const simpleAdminRoutes = require('./routes/simple-admin');
+const createSimpleAdminRouter = require('./routes/simple-admin');
+const RBACManager = require('./services/RBACManager');
 
 // Use routes
 app.use('/api/chat', chatRoutes);
@@ -72,10 +71,13 @@ async function startServer() {
     await initializeRAGAnalyticsRoutes();
     console.log('✅ RAG Analytics routes initialized successfully');
 
-    // Mount simple admin routes
-    console.log('🔧 Mounting admin routes...');
+    // Mount simple admin routes with RBAC protection
+    console.log('🔐 Configuring admin authentication middleware...');
+    const rbacManager = new RBACManager();
+    const simpleAdminRoutes = createSimpleAdminRouter({ rbacManager });
+    app.locals.rbacManager = rbacManager;
     app.use('/api/admin', simpleAdminRoutes);
-    console.log('✅ Admin routes mounted successfully');
+    console.log('✅ Admin routes secured and mounted successfully');
     
     // Initialize WebSocket server
     console.log('🔌 Initializing WebSocket server...');


### PR DESCRIPTION
## Summary
- add RBAC-backed authorization middleware to the simple admin router and allow dependency injection for testing
- ensure the server mounts /api/admin with the RBAC manager so the endpoints are protected
- add integration tests that cover authorized and unauthorized access to the RAG config endpoints

## Testing
- npx jest --config package.json __tests__/integration/simple-admin-auth.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d0c86799ec8333999ebeea76784b4e